### PR TITLE
Sort results from find

### DIFF
--- a/mgitstatus
+++ b/mgitstatus
@@ -110,7 +110,7 @@ else
 fi
 
 # Find all .git dirs, up to DEPTH levels deep
-find -L "$ROOT_DIR" -maxdepth "$DEPTH" -type d | while read -r PROJ_DIR
+find -L "$ROOT_DIR" -maxdepth "$DEPTH" -type d | sort | while read -r PROJ_DIR
 do
     GIT_DIR="$PROJ_DIR/.git"
     GIT_CONF="$PROJ_DIR/.git/config"


### PR DESCRIPTION
The results being returned in a more or less random order is rather unpleasant.
When running `mgitstatus | sort`, the output looses all its colors, that's why I am proposing a change to the script itself.
Please let me know if this is too simple of a fix and you'd rather like a switch to allow users to decide if they want the output sorted or not.