### PR TITLE
Fix '-e' option

### DIFF
--- a/mgitstatus
+++ b/mgitstatus
@@ -60,7 +60,7 @@ NO_STASHES=0
 
 while [ ! -z "$1" ]; do
     # Stop reading when we've run out of options.
-    [ "$(echo "$1" | cut -c 1)" != "-" ] && break
+    [ "$(printf "%s" "$1" | cut -c 1)" != "-" ] && break
 
     if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
         usage


### PR DESCRIPTION
echo "$1" | cut -c 1 doesn't work with '-e'. It seems that '-e' is interpreted as an option of echo. A possibility I saw to fix quickly, is to use printf instead. Maybe you like to merge that fix.