### PR TITLE
mgitstatus -b shall print current branch unless master

### DIFF
--- a/mgitstatus
+++ b/mgitstatus
@@ -20,6 +20,7 @@ deep.
   -e             Exclude repos that are 'ok'
   -f             Do a 'git fetch' on each repo (slow for many repos)
   -c             Force color output (preserve colors when using pipes)
+  -b             Show current branch
   -d, --depth=2  Scan this many directories deep
 
 You can limit output with the following options:
@@ -45,6 +46,7 @@ NO_UPSTREAM=0
 NO_UNCOMMITTED=0
 NO_UNTRACKED=0
 NO_STASHES=0
+DO_STATUS=0
 DEPTH=2
 
 while [ -n "$1" ]; do
@@ -70,6 +72,9 @@ while [ -n "$1" ]; do
     fi
     if [ "$1" = "-c" ]; then
         FORCE_COLOR=1
+    fi
+    if [ "$1" = "-b" ]; then
+        DO_STATUS=1
     fi
     if [ "$1" = "--no-push" ]; then
         NO_PUSH=1
@@ -239,9 +244,15 @@ for DIR in "${@:-"."}"; do
         STASHES=$(git stash list | wc -l)
         cd "$OLDPWD" || exit
 
+        CURRENT_BRANCH=$(git --work-tree "$(dirname "$GIT_DIR")" --git-dir "$GIT_DIR"  branch --show-current)
+
         # Build up the status string
         IS_OK=0  # 0 = Repo needs something, 1 = Repo needs nothing ('ok')
         STATUS_NEEDS=""
+        BRANCH_PRINT=""
+        if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "master" ] && [ "$DO_STATUS" -eq 1 ]; then
+            BRANCH_PRINT="[${C_OK}${CURRENT_BRANCH}${C_RESET}] "
+        fi
         if [ -n "$NEEDS_PUSH_BRANCHES" ] && [ "$NO_PUSH" -eq 0 ]; then
             STATUS_NEEDS="${STATUS_NEEDS}${C_NEEDS_PUSH}Needs push ($NEEDS_PUSH_BRANCHES)${C_RESET} "
         fi
@@ -262,7 +273,9 @@ for DIR in "${@:-"."}"; do
         fi
         if [ "$STATUS_NEEDS" = "" ]; then
             IS_OK=1
-            STATUS_NEEDS="${STATUS_NEEDS}${C_OK}ok${C_RESET} "
+            STATUS_NEEDS="${BRANCH_PRINT}${STATUS_NEEDS}${C_OK}ok${C_RESET} "
+        else
+            STATUS_NEEDS="${BRANCH_PRINT}${STATUS_NEEDS}"
         fi
 
         # Print the output, unless repo is 'ok' and -e was specified

--- a/mgitstatus.1
+++ b/mgitstatus.1
@@ -8,7 +8,7 @@ mgitstatus \[en] Show uncommitted, untracked and unpushed changes for
 multiple Git repos.
 .SH SYNOPSIS
 .PP
-\f[B]mgitstatus\f[] [\f[B]\-\-version\f[]] [\f[B]\-w\f[]] [\f[B]\-e\f[]]
+\f[B]mgitstatus\f[] [\f[B]\-\-version\f[]] [\f[B]\-b\f[]] [\f[B]\-w\f[]] [\f[B]\-e\f[]]
 [\f[B]\-f\f[]] [\f[B]\-\-no\-X\f[]] [\f[B]\-d/\-\-depth\f[]=2]
 [\f[B]DIR\f[] [\f[B]DIR\f[]]...]
 .SH DESCRIPTION
@@ -20,6 +20,8 @@ This can be changed with the \f[C]\-d\f[] (\f[C]\-\-depth\f[]) option.
 If \f[B]DEPTH\f[] is 0, the scan is infinitely deep.
 .PP
 mgitstatus shows:
+.IP \[bu] 2
+\f[B]Current branch\f[] if the option -b is given.
 .IP \[bu] 2
 \f[B]Uncommitted changes\f[] if there are unstaged or uncommitted
 changes on the checked out branch.
@@ -49,6 +51,11 @@ mgitstatus makes no guarantees that all states are taken into account.
 .TP
 .B \f[B]\-\-version\f[]
 Show version
+.RS
+.RE
+.TP
+.B \f[B]\-b\f[]
+Print current branch (master is skipped)
 .RS
 .RE
 .TP

--- a/mgitstatus.1.md
+++ b/mgitstatus.1.md
@@ -19,6 +19,8 @@ is infinitely deep.
 
 mgitstatus shows:
 
+- **Current branch** if the -b option is given. Skips 'master' branch.
+
 - **Uncommitted changes** if there are unstaged or uncommitted changes on the
   checked out branch.
 
@@ -45,6 +47,9 @@ mgitstatus makes no guarantees that all states are taken into account.
 
 **--version**
 :   Show version
+
+**-b**
+:   Print current branch
 
 **-w**
 :   Warn about dirs that are not Git repositories


### PR DESCRIPTION
We've found it useful to combine a git branch --show-current in mgitstatus scan. option -b.