### PR TITLE
Fix manpage dash

### DIFF
--- a/mgitstatus.1.md
+++ b/mgitstatus.1.md
@@ -8,7 +8,7 @@ mgitstatus - Show uncommitted, untracked and unpushed changes for multiple Git r
 
 # SYNOPSIS
 
- **mgitstatus** [**--version**] [**-w**] [**-e**] [**-f**] [**--no-X**] [**-d/--depth**=2] [**DIR** [**DIR**]...]
+ **mgitstatus** [**\--version**] [**-w**] [**-e**] [**-f**] [**\--no-X**] [**-d/\--depth**=2] [**DIR** [**DIR**]...]
 
 # DESCRIPTION
 
@@ -43,7 +43,7 @@ mgitstatus makes no guarantees that all states are taken into account.
 
 # OPTIONS
 
-**--version**
+**\--version**
 :   Show version
 
 **-w**
@@ -58,27 +58,27 @@ mgitstatus makes no guarantees that all states are taken into account.
 **-c**
 :   Force color output (preserve colors when using pipes)
 
-**-d, --depth=2**
+**-d, \--depth=2**
 :   Scan this many directories deep. Default is 2. If **0**, the scan is infinitely deep
 
 You can limit output with the following options:
 
-**--no-push**
+**\--no-push**
 :   Do not show branches that need a push.
 
-**--no-pull**
+**\--no-pull**
 :   Do not show branches that need a pull.
 
-**--no-upstream**
+**\--no-upstream**
 :   Do not show branches that need an upstream.
 
-**--no-uncommited**
+**\--no-uncommitted**
 :   Do not show branches that have unstaged or uncommitted changes.
 
-**--no-untracked**
+**\--no-untracked**
 :   Do not show branches that have untracked files.
 
-**--no-stashes**
+**\--no-stashes**
 :   Do now show stashes
 
 

--- a/mgitstatus.1.md
+++ b/mgitstatus.1.md
@@ -4,7 +4,7 @@
 
 # NAME
 
-mgitstatus – Show uncommitted, untracked and unpushed changes for multiple Git repos.
+mgitstatus - Show uncommitted, untracked and unpushed changes for multiple Git repos.
 
 # SYNOPSIS
 


### PR DESCRIPTION
There are two issues with the dash in the man page.

First of all, in the `NAME` section, there is a non-ascii dash. This make stricter groff parsers such as [lexgrog](https://www.man7.org/linux/man-pages/man1/lexgrog.1.html#WHATIS_PARSING) fail. Simply replacing by the ascii dash fixes the issue.

Secondly, `--`, used by the options, can have a special meaning in markdown. The issue here is that when building with pandoc 2.~, it will convert it to a non-ascci **single** dash (`--version` to `-version` for instance).

To preserve the correct meaning of the dashes and for it to work with any version of pandoc, `--` must be escaped to `\--`.

See this [pandoc issue](https://github.com/jgm/pandoc/issues/5404) for more info.