### PR TITLE
Added [-s] option to sort results

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ for that repo to `true`. (See "usage" below for an example).
 
 # Usage
 
-    Usage: ./mgitstatus [--version] [-w] [-e] [-f] [--no-X] [-d/--depth=2] [DIR [DIR]...]
+    Usage: ./mgitstatus [--version] [-w] [-e] [-f] [-s] [--no-X] [-d/--depth=2] [DIR [DIR]...]
 
     mgitstatus shows uncommitted, untracked and unpushed changes in multiple Git
     repositories.  By default, mgitstatus scans two directories deep. This can be
@@ -44,6 +44,7 @@ for that repo to `true`. (See "usage" below for an example).
       -w             Warn about dirs that are not Git repositories
       -e             Exclude repos that are 'ok'
       -f             Do a 'git fetch' on each repo (slow for many repos)
+      -s             Sort dirs alphabetically
       -c             Force color output (preserve colors when using pipes)
       -d, --depth=2  Scan this many directories deep
 

--- a/mgitstatus
+++ b/mgitstatus
@@ -8,7 +8,7 @@ DEBUG=0
 usage () {
     cat << EOF >&2
     
-Usage: $0 [--version] [-w] [-e] [-f] [--no-X] [-d/--depth=2] [DIR [DIR]...]
+Usage: $0 [--version] [-w] [-e] [-f] [-s] [--no-X] [-d/--depth=2] [DIR [DIR]...]
 
 mgitstatus shows uncommitted, untracked and unpushed changes in multiple Git
 repositories.  By default, mgitstatus scans two directories deep. This can be
@@ -19,6 +19,7 @@ deep.
   -w             Warn about dirs that are not Git repositories
   -e             Exclude repos that are 'ok'
   -f             Do a 'git fetch' on each repo (slow for many repos)
+  -s             Sort dirs alphabetically
   -c             Force color output (preserve colors when using pipes)
   -d, --depth=2  Scan this many directories deep
 
@@ -46,6 +47,7 @@ NO_UNCOMMITTED=0
 NO_UNTRACKED=0
 NO_STASHES=0
 DEPTH=2
+SORT="-z"
 
 while [ -n "$1" ]; do
     # Stop reading when we've run out of options.
@@ -70,6 +72,9 @@ while [ -n "$1" ]; do
     fi
     if [ "$1" = "-c" ]; then
         FORCE_COLOR=1
+    fi
+	if [ "$1" = "-s" ]; then
+        SORT="-n"
     fi
     if [ "$1" = "--no-push" ]; then
         NO_PUSH=1
@@ -135,7 +140,7 @@ fi
 for DIR in "${@:-"."}"; do
     # We *want* to expand parameters, so disable shellcheck for this error:
     # shellcheck disable=SC2086
-    find -L "$DIR" $FIND_OPTS -type d | while read -r PROJ_DIR
+    find -L "$DIR" $FIND_OPTS -type d | sort $SORT | while read -r PROJ_DIR
     do
         GIT_DIR="$PROJ_DIR/.git"
         GIT_CONF="$PROJ_DIR/.git/config"

--- a/mgitstatus
+++ b/mgitstatus
@@ -128,6 +128,7 @@ C_NEEDS_COMMIT="$C_RED"
 C_NEEDS_UPSTREAM="$C_PURPLE"
 C_UNTRACKED="$C_CYAN"
 C_STASHES="$C_YELLOW"
+C_NOT_REPO="$C_CYAN"
 
 # Find all .git dirs, up to DEPTH levels deep. If DEPTH is 0, the scan in
 # infinitely deep
@@ -154,7 +155,7 @@ for DIR in "${@:-"."}"; do
         # If this dir is not a repo, and WARN_NOT_REPO is 1, tell the user.
         if [ ! -d "$GIT_DIR" ]; then
             if [ "$WARN_NOT_REPO" -eq 1 ] && [ "$PROJ_DIR" != "." ]; then
-                printf "${PROJ_DIR}: not a git repo\n"
+                printf "${PROJ_DIR}: ${C_NOT_REPO}Not a git repo${C_RESET}\n"
             fi
             continue
         fi

--- a/mgitstatus.1
+++ b/mgitstatus.1
@@ -9,7 +9,7 @@ multiple Git repos.
 .SH SYNOPSIS
 .PP
 \f[B]mgitstatus\f[R] [\f[B]\-\-version\f[R]] [\f[B]\-w\f[R]]
-[\f[B]\-e\f[R]] [\f[B]\-f\f[R]] [\f[B]\-\-no\-X\f[R]]
+[\f[B]\-e\f[R]] [\f[B]\-f\f[R]] [\f[B]\-s\f[R]] [\f[B]\-\-no\-X\f[R]]
 [\f[B]\-d/\-\-depth\f[R]=2] [\f[B]DIR\f[R] [\f[B]DIR\f[R]]\&...]
 .SH DESCRIPTION
 .PP
@@ -58,6 +58,9 @@ Exclude repos that are `ok'
 .TP
 .B \f[B]\-f\f[R]
 Do a `git fetch' on each repo (slow for many repos)
+.TP
+.B \f[B]\-s\f[R]
+Sort dirs alphabetically
 .TP
 .B \f[B]\-c\f[R]
 Force color output (preserve colors when using pipes)

--- a/mgitstatus.1.md
+++ b/mgitstatus.1.md
@@ -8,7 +8,7 @@ mgitstatus - Show uncommitted, untracked and unpushed changes for multiple Git r
 
 # SYNOPSIS
 
- **mgitstatus** [**\--version**] [**-w**] [**-e**] [**-f**] [**\--no-X**] [**-d/\--depth**=2] [**DIR** [**DIR**]...]
+ **mgitstatus** [**\--version**] [**-w**] [**-e**] [**-f**] [**-s**] [**\--no-X**] [**-d/\--depth**=2] [**DIR** [**DIR**]...]
 
 # DESCRIPTION
 
@@ -54,6 +54,9 @@ mgitstatus makes no guarantees that all states are taken into account.
 
 **-f**
 :   Do a 'git fetch' on each repo (slow for many repos)
+
+**-s**
+:   Sort dirs alphabetically
 
 **-c**
 :   Force color output (preserve colors when using pipes)


### PR DESCRIPTION
Included a piped `sort` in the `find` command that parses directories. If `-s` is not set, `sort` uses its `-z` option to basically mimic the default order of `find` results. If `-s` is set, `sort` uses its `-n` option to do a numeric sort. Of course, several other of the native `sort` options could be included in future. This sorting method also retains color output without having to use the `-c` option.